### PR TITLE
Harden the words= selection feature

### DIFF
--- a/.github/workflows/py_test.yml
+++ b/.github/workflows/py_test.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.12"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: HTTP Server Action
         uses: Eun/http-server-action@v1.0.10
         with:
@@ -43,7 +43,7 @@ jobs:
           log: "log.txt"
           logTime: "false"
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install software

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.12"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,18 @@ are baked in at build time in `Ayah.__init__`.
   (`visibility:hidden`), so the Madina stretch/offset geometry is preserved and only the chosen words
   are visible. A selection that fits one line renders inline; otherwise it gets the multiline block +
   header. Aya-number ornaments (`AYA_MARKER`) are never counted. See `appendWords()`.
+  Validation/limits in this path: `parseWordsRange()` rejects a malformed, zero/negative, or reversed
+  range (`start > end`) by returning `null`, and `doRender()` then **falls back to the normal verse
+  render** (logs `Bad words parameter`). The span is **capped at 500 words** (`doRender` clamps
+  `range[1]`). Because counting is per-word, `collectWordParts()` returns `{groups, counterStart}` and
+  **trims fully-hidden lines** off both ends — leading lines before `range[0]` and trailing lines after
+  `range[1]` (the latter occur because collection grabs whole ayas that spill onto further lines), so
+  the block always starts and ends on a line that shows a selected word; `counterStart` carries the
+  skipped leading words so visibility still lines up. `countPartWords()` counts a single part (and
+  `countAyaWords()` sums it over an aya). Combining `words` with an `aya` **range** ignores the range
+  end (only the start aya seeds the walk) and logs a warning. The copy button (`copyToClipboard()` via
+  `visibleClone()`) copies only visible text — it strips the header, `quran-madina-html-word-hidden`
+  spans, and `visibility:hidden` spacers from a detached clone rather than trusting `innerText`.
 - A range that fits on one line renders as an inline `<span>`; otherwise a multiline `<div>` with a
   header (sura name + copy/translate icons). Generated child tags: `<quran-madina-html-line>`,
   `<quran-madina-html-header>`, `<quran-madina-html-copy>`, and per-aya `<div>`s classed

--- a/src/quran-madina-html.js
+++ b/src/quran-madina-html.js
@@ -72,16 +72,21 @@
     var parts = str.split(/[-:]/).map(elem => parseInt(elem, 10));
     if(parts.length == 1) parts = [parts[0], parts[0]];
     if(parts.length != 2 || isNaN(parts[0]) || isNaN(parts[1])) return null;
+    if(parts[0] < 1 || parts[1] < parts[0]) return null; // 1-based; start must not exceed end
     return parts;
   }
-  function countAyaWords(aya){
-    // Number of selectable words in an aya (whitespace-separated, excluding aya-number markers).
+  function countPartWords(part){
+    // Selectable words in a single render part (whitespace-separated, excluding aya-number markers).
     var n = 0;
-    aya.r.forEach(function(part){
-      part.t.split(/\s+/).forEach(function(token){
-        if(token !== "" && !AYA_MARKER.test(token)) n = n + 1;
-      });
+    part.t.split(/\s+/).forEach(function(token){
+      if(token !== "" && !AYA_MARKER.test(token)) n = n + 1;
     });
+    return n;
+  }
+  function countAyaWords(aya){
+    // Number of selectable words in an aya, summed over its render parts.
+    var n = 0;
+    aya.r.forEach(function(part){ n = n + countPartWords(part); });
     return n;
   }
   function appendWords(parent, text, range, counter){
@@ -165,14 +170,30 @@
       }
       if(reached) break;
     }
-    return groups;
+    // Annotate each visual line with the running countable-word index it ends at, then drop the
+    // lines that are entirely outside the selection — leading lines before range[0] and trailing
+    // lines after range[1] (the latter appear because collection grabs whole ayas, which may run
+    // onto further lines). The block then begins and ends on lines that actually show a selected
+    // word (requirement: no fully-hidden lines). Words on dropped leading lines are carried over as
+    // `counterStart` so word visibility downstream still lines up.
+    var running = 0;
+    groups.forEach(function(g){
+      g.parts.forEach(function(item){ if(item.countable){ running = running + countPartWords(item.part); } });
+      g.lastWord = running;
+    });
+    var start = 0;
+    while(start < groups.length - 1 && groups[start].lastWord < range[0]) start = start + 1;
+    var end = start;
+    while(end < groups.length - 1 && groups[end].lastWord < range[1]) end = end + 1;
+    return {groups: groups.slice(start, end + 1), counterStart: start > 0 ? groups[start - 1].lastWord : 0};
   }
   function renderWordsSpan(tag, sura_start, aya_start, range, headless){
     // Dedicated render path for the words= selection. Unlike the page/aya loop it is not bound
     // to a single page or sura, so a word range can span both.
-    var groups = collectWordParts(sura_start, aya_start, range);
+    var collected = collectWordParts(sura_start, aya_start, range);
+    var groups = collected.groups;
     var multiline = groups.length > 1;
-    var counter = 0; // running 1-based word index from the start aya, drives word visibility
+    var counter = collected.counterStart; // running 1-based word index, seeded past any skipped lines
     tag.innerHTML = "";
     tag.removeAttribute('style');
     if(multiline){
@@ -183,11 +204,11 @@
         tag.style.setProperty('line-height', madina_data.font_size*2+"px", '');
       }
       tag.style.width = (madina_data.line_width+10)+"px";
-      let start_page = madina_data.suras[sura_start].ayas[aya_start].p;
+      let start_page = parseInt(groups[0].key.split(':')[0], 10); // page of the first visible line
       tag.style.setProperty('box-shadow', 'inset '+(start_page%2==1?"":"-")+'8px 0 7px -7px #333', '');
       if(!headless){
         let header = document.createElement("quran-madina-html-header");
-        header.innerHTML = madina_data.suras[sura_start].name;
+        header.innerHTML = madina_data.suras[groups[0].parts[0].sura].name;
         let copy = getCopyIcon(); copy.addEventListener("click", copyToClipboard);
         let translation = getTranslateIcon(); translation.addEventListener("click", openTranslate);
         header.appendChild(copy); header.appendChild(translation);
@@ -317,14 +338,42 @@
   function print(str){
     console.log(`${name}> ${str}`);
   }
+  function visibleClone(host){
+    // Clone the rendered tag and strip everything that must not be copied: the header chrome,
+    // word spans hidden by a words= selection, and the invisible layout spacers. Working on a
+    // detached clone lets us read textContent (no layout needed) instead of relying on innerText's
+    // browser-specific handling of visibility:hidden.
+    var clone = host.cloneNode(true);
+    var header = clone.querySelector("quran-madina-html-header");
+    if(header) header.parentNode.removeChild(header);
+    Array.from(clone.querySelectorAll(`.${name}-word-hidden`)).forEach(function(e){
+      e.parentNode.removeChild(e);
+    });
+    Array.from(clone.querySelectorAll("div,span")).forEach(function(e){
+      if(/visibility:\s*hidden/.test(e.getAttribute("style") || "")) e.parentNode.removeChild(e);
+    });
+    return clone;
+  }
   function copyToClipboard(){
-    textWithHeader = this.parentElement.parentElement.innerText.split("\n");
-    if(textWithHeader.length > 1){
-      text = textWithHeader.slice(1).join(" ") + "\n\n" + textWithHeader[0];
+    var host = this.parentElement.parentElement;
+    var header = host.querySelector("quran-madina-html-header");
+    var sura_name;
+    if(header){
+      sura_name = header.textContent.replace(/\s+/g, " ").trim(); // icons are svg, contribute no text
     } else {
-      let sura_index = this.parentElement.parentElement.getAttribute("sura");
-      text = textWithHeader[0]+ "\n\n" + madina_data.suras[sura_index-1].name;
+      let sura_index = host.getAttribute("sura");
+      sura_name = (sura_index != null) ? madina_data.suras[sura_index - 1].name : "";
     }
+    var clone = visibleClone(host);
+    var lines = clone.querySelectorAll("quran-madina-html-line");
+    var body;
+    if(lines.length){
+      body = Array.from(lines).map(function(l){ return l.textContent.replace(/\s+/g, " ").trim(); })
+                  .filter(function(s){ return s !== ""; }).join(" ");
+    } else {
+      body = clone.textContent.replace(/\s+/g, " ").trim();
+    }
+    var text = body + "\n\n" + sura_name;
     navigator.clipboard.writeText(text);
     alert("\u2398 تم نسخ:\n\n" + text);
   }
@@ -491,6 +540,11 @@
                     if(words_range == null){
                       print(`Bad words parameter: ${this.words}`);
                     } else {
+                      if(aya_to !== aya_from) print("Ignoring aya range end with words parameter!");
+                      if(words_range[1] - words_range[0] + 1 > 500){
+                        print("words selection capped at 500 words");
+                        words_range[1] = words_range[0] + 499;
+                      }
                       // words= has its own renderer that spans pages and suras from the start aya.
                       renderWordsSpan(tag, sura_from, aya_from, words_range, headless);
                       return;

--- a/test/render_test.py
+++ b/test/render_test.py
@@ -240,5 +240,49 @@ class BasicRenderTest(unittest.TestCase):
         self.set_attrs(sura=1, aya="1-7", headless="False")
         self.assertEqual(self.count("quran-madina-html-header"), 1, "headless=False keeps header")
 
+    def test_12_words_invalid_range_falls_back(self):
+        """A reversed or zero words= range is rejected; the aya renders normally (no word spans)"""
+        for bad in ("3-1", "0", "0-2"):
+            self.set_attrs(sura=1, aya=1, words=bad)
+            self.assertEqual(self.count("span.quran-madina-html-word"), 0,
+                             f"words={bad} should not split into word spans\n{self.dump_log()}")
+            self.assertGreaterEqual(self.count("quran-madina-html-line"), 1,
+                                    f"words={bad} should still render the aya")
+
+    def test_13_words_capped_at_500(self):
+        """An over-long words= span is capped at 500 visible words"""
+        self.set_attrs(sura=1, aya=1, words="1-1000")
+        self.assertEqual(len(self.visible_words()), 500, f"selection capped at 500\n{self.dump_log()}")
+
+    def test_14_words_no_fully_hidden_leading_lines(self):
+        """Leading lines that are entirely hidden are skipped: every word line shows >=1 word"""
+        self.set_attrs(sura=1, aya=1, words="20-22")
+        expected = collect_words(self.db["suras"], 0, 2, 22)[19:22]
+        self.assertEqual(self.visible_words(), expected,
+                         f"words=20-22 should show words 20..22\n{self.dump_log()}")
+        fully_hidden = self.web_driver.execute_script(
+            "return Array.from(document.querySelectorAll('quran-madina-html-line')).filter("
+            "function(line){var w=line.querySelectorAll('span.quran-madina-html-word');"
+            "return w.length>0 && Array.from(w).every(function(s){"
+            "return s.classList.contains('quran-madina-html-word-hidden');});}).length;")
+        self.assertEqual(fully_hidden, 0, "no rendered line may be entirely hidden")
+
+    def test_15_copy_excludes_hidden_words(self):
+        """Copy-to-clipboard carries only the visible words, not the ones hidden by words="""
+        self.set_attrs(sura=1, aya=1, words="1:2")
+        self.web_driver.execute_script(
+            "window.__copied=null;window.alert=function(){};"
+            "navigator.clipboard.writeText=function(t){window.__copied=t;return Promise.resolve();};")
+        self.web_driver.execute_script(
+            "document.querySelector('quran-madina-html-copy svg')."
+            "dispatchEvent(new MouseEvent('click',{bubbles:true}));")
+        copied = self.web_driver.execute_script("return window.__copied;")
+        shown = collect_words(self.db["suras"], 0, 2, 3)
+        self.assertIsNotNone(copied, f"copy handler should have run\n{self.dump_log()}")
+        self.assertIn(shown[0], copied)
+        self.assertIn(shown[1], copied)
+        self.assertNotIn(shown[2], copied, "a hidden word must not be copied")
+        self.assertIn(self.db["suras"][0]["name"], copied, "sura name is appended to the copy")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fix several edge cases in the words= render path and document them:

- Reject invalid ranges (zero, negative, or reversed start>end) in parseWordsRange(); doRender() falls back to the normal verse render instead of producing a silent blank.
- Cap a selection at 500 words so an over-long range (e.g. a typo like words="1-100000") can no longer walk the whole mushaf and hang.
- Trim fully-hidden lines off both ends of the selection: collectWordParts() now returns {groups, counterStart} and drops leading lines before the start word and trailing lines after the end word (the latter appear because collection grabs whole ayas that spill onto further lines), so the block always begins and ends on a line that shows a selected word.
- Warn when words= is combined with an aya range, whose end is ignored.
- Copy only visible text: copyToClipboard() now strips the header, word-hidden spans, and visibility:hidden spacers from a detached clone rather than relying on innerText's browser-specific handling.

Add render_test cases for each (invalid-range fallback, 500-word cap, no fully-hidden lines, copy excludes hidden words) and update CLAUDE.md.